### PR TITLE
Tweak ansible-playbook call to get around Ansible: no hosts matched

### DIFF
--- a/platform/documentation/environments/dev/index.md
+++ b/platform/documentation/environments/dev/index.md
@@ -90,7 +90,7 @@ At this point, you have the platform container running on your local machine as 
 Run the following command to install the dockerized application:
 
 ```
-ansible-playbook ./install.yml
+ansible-playbook ./install.yml -i inventory.yml
 ```
 
 > Note: Depending on the power of your machine and internet speed, this command may take a while to finish.


### PR DESCRIPTION
Without this change, the tasks in the ansible-playbook would not run.

In trying to get the development environment up and running, executing the existing ansible-playbook command referred to an issue described here: https://stackoverflow.com/questions/38203317/ansible-no-hosts-matched

I am not sure if this is the best, or correct solution, but adding an -i inventory.yml included the already existing inventory file explicitly in the ansible-playbook call and most of the installation seemed to work.